### PR TITLE
Create PREPROCESSOR.md

### DIFF
--- a/C++/PREPROCESSOR.md
+++ b/C++/PREPROCESSOR.md
@@ -1,0 +1,93 @@
+# PREPROCESSOR
+
+To define **Kilo Preprocessor, Micro Preprocessor, Nano Preprocessor, and Pico Preprocessor** in C-family languages (C, C++, Objective-C), we can approach this by designing different levels of **preprocessor macros** that define various levels of code processing, optimization, and conditional compilation.
+
+---
+
+### **Preprocessor Tiers**
+Each preprocessor level will enable different levels of macro expansion, optimization, and debugging aids:
+
+1. **Kilo Preprocessor (Basic Macro Expansion, Debugging Support)**
+2. **Micro Preprocessor (Optimized Code Reduction)**
+3. **Nano Preprocessor (Minimalistic Compilation, Tiny Footprint)**
+4. **Pico Preprocessor (Extreme Compression, No Debugging)**
+
+---
+
+### **Implementation in C/C++**
+We define different levels of preprocessing using `#define` directives to control code expansion at different levels.
+
+```c
+#ifndef PREPROCESSOR_LEVEL
+    #define PREPROCESSOR_LEVEL 1000  // Default to Kilo Preprocessor
+#endif
+
+#if PREPROCESSOR_LEVEL >= 1000
+    #define KILO_PREPROCESSOR
+    #define ENABLE_DEBUG
+    #define ENABLE_LOGGING
+    #define VERBOSE_MODE
+    #define INLINE_EXPANSION  // Expand functions inline for performance
+    #pragma message("Kilo Preprocessor Enabled: Full debug and logging support")
+#endif
+
+#if PREPROCESSOR_LEVEL >= 100
+    #define MICRO_PREPROCESSOR
+    #define OPTIMIZED_CODE
+    #undef ENABLE_DEBUG   // No debug mode
+    #undef ENABLE_LOGGING // No logging
+    #define INLINE_FUNCTIONS
+    #pragma message("Micro Preprocessor Enabled: Optimized code, no debugging")
+#endif
+
+#if PREPROCESSOR_LEVEL >= 10
+    #define NANO_PREPROCESSOR
+    #define MINIMAL_CODE
+    #undef INLINE_FUNCTIONS
+    #pragma message("Nano Preprocessor Enabled: Minimalistic code, no optimizations")
+#endif
+
+#if PREPROCESSOR_LEVEL >= 1
+    #define PICO_PREPROCESSOR
+    #define EXTREME_COMPRESSION
+    #undef MINIMAL_CODE
+    #pragma message("Pico Preprocessor Enabled: Extreme size reduction, no debugging")
+#endif
+```
+
+---
+
+### **How to Use It**
+You can control the preprocessor level when compiling using `-D` flags.
+
+#### **Example 1: Enabling Kilo Preprocessor**
+```bash
+gcc -DPREPROCESSOR_LEVEL=1000 main.c -o program
+```
+This enables debugging, logging, and function inlining.
+
+#### **Example 2: Enabling Nano Preprocessor**
+```bash
+gcc -DPREPROCESSOR_LEVEL=10 main.c -o program
+```
+This removes debugging, reduces size, and prevents inline functions.
+
+#### **Example 3: Enabling Pico Preprocessor**
+```bash
+gcc -DPREPROCESSOR_LEVEL=1 main.c -o program
+```
+This enables extreme compression by stripping out all unnecessary features.
+
+---
+
+### **Summary of Preprocessor Tiers**
+| Preprocessor Level | Features Enabled                          | Features Removed |
+|--------------------|------------------------------------------|-----------------|
+| **Kilo (1000)**   | Debugging, Logging, Verbose, Inline      | None |
+| **Micro (100)**   | Optimized Code, No Debugging/Logging     | Debugging, Logging |
+| **Nano (10)**     | Minimal Code, No Inline                  | Optimizations |
+| **Pico (1)**      | Extreme Compression                      | Everything Extra |
+
+This setup provides flexibility, allowing different builds of the same source code by toggling preprocessor levels.
+
+Would you like further refinements or additional feature toggles? 🚀


### PR DESCRIPTION
```markdown
# PREPROCESSOR

To define **Kilo Preprocessor, Micro Preprocessor, Nano Preprocessor, and Pico Preprocessor** in C-family languages (C, C++, Objective-C), we can approach this by designing different levels of **preprocessor macros** that define various levels of code processing, optimization, and conditional compilation.

---

### **Preprocessor Tiers**
Each preprocessor level will enable different levels of macro expansion, optimization, and debugging aids:

1. **Kilo Preprocessor (Basic Macro Expansion, Debugging Support)**
2. **Micro Preprocessor (Optimized Code Reduction)**
3. **Nano Preprocessor (Minimalistic Compilation, Tiny Footprint)**
4. **Pico Preprocessor (Extreme Compression, No Debugging)**

---

### **Implementation in C/C++**
We define different levels of preprocessing using `#define` directives to control code expansion at different levels.

```c
#ifndef PREPROCESSOR_LEVEL
    #define PREPROCESSOR_LEVEL 1000  // Default to Kilo Preprocessor
#endif

#if PREPROCESSOR_LEVEL >= 1000
    #define KILO_PREPROCESSOR
    #define ENABLE_DEBUG
    #define ENABLE_LOGGING
    #define VERBOSE_MODE
    #define INLINE_EXPANSION  // Expand functions inline for performance
    #pragma message("Kilo Preprocessor Enabled: Full debug and logging support")
#endif

#if PREPROCESSOR_LEVEL >= 100
    #define MICRO_PREPROCESSOR
    #define OPTIMIZED_CODE
    #undef ENABLE_DEBUG   // No debug mode
    #undef ENABLE_LOGGING // No logging
    #define INLINE_FUNCTIONS
    #pragma message("Micro Preprocessor Enabled: Optimized code, no debugging")
#endif

#if PREPROCESSOR_LEVEL >= 10
    #define NANO_PREPROCESSOR
    #define MINIMAL_CODE
    #undef INLINE_FUNCTIONS
    #pragma message("Nano Preprocessor Enabled: Minimalistic code, no optimizations")
#endif

#if PREPROCESSOR_LEVEL >= 1
    #define PICO_PREPROCESSOR
    #define EXTREME_COMPRESSION
    #undef MINIMAL_CODE
    #pragma message("Pico Preprocessor Enabled: Extreme size reduction, no debugging")
#endif
```

---

### **How to Use It**
You can control the preprocessor level when compiling using `-D` flags.

#### **Example 1: Enabling Kilo Preprocessor**
```bash
gcc -DPREPROCESSOR_LEVEL=1000 main.c -o program
```
This enables debugging, logging, and function inlining.

#### **Example 2: Enabling Nano Preprocessor**
```bash
gcc -DPREPROCESSOR_LEVEL=10 main.c -o program
```
This removes debugging, reduces size, and prevents inline functions.

#### **Example 3: Enabling Pico Preprocessor**
```bash
gcc -DPREPROCESSOR_LEVEL=1 main.c -o program
```
This enables extreme compression by stripping out all unnecessary features.

---

### **Summary of Preprocessor Tiers**
| Preprocessor Level | Features Enabled                          | Features Removed |
|--------------------|------------------------------------------|-----------------|
| **Kilo (1000)**   | Debugging, Logging, Verbose, Inline      | None |
| **Micro (100)**   | Optimized Code, No Debugging/Logging     | Debugging, Logging |
| **Nano (10)**     | Minimal Code, No Inline                  | Optimizations |
| **Pico (1)**      | Extreme Compression                      | Everything Extra |

This setup provides flexibility, allowing different builds of the same source code by toggling preprocessor levels.

Would you like further refinements or additional feature toggles? 🚀
```